### PR TITLE
fix: npm ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: 20
 
       - name: Install dependencies
-        run: npm ci
+        run: npm i
 
       - name: Create new version & update changelog
         run: |


### PR DESCRIPTION
switch npm ci to npm i in reason of package-lock.json is in git ignore